### PR TITLE
Add filename and extension search term option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ $ ghkw exclusion_condition exclude_condition excluded_condition
 ```
 --language     Add language to search term.
 
+--filename     Add filename to search term.
+
 -d, --debug    Enable debug mode.
                Print debug log.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ $ ghkw exclusion_condition exclude_condition excluded_condition
 
 --filename     Add filename to search term.
 
+--extension    Add extension to search term.
+
 -d, --debug    Enable debug mode.
                Print debug log.
 

--- a/cli.go
+++ b/cli.go
@@ -63,15 +63,17 @@ type Searcher struct {
 	keywordsWithTotal map[string]int
 	language          string
 	filename          string
+	extension         string
 }
 
 // Run invokes the CLI with the given arguments
 func (c *CLI) Run(args []string) int {
 	var (
-		debug    bool
-		language string
-		filename string
-		version  bool
+		debug     bool
+		language  string
+		filename  string
+		extension string
+		version   bool
 	)
 	flags := flag.NewFlagSet(args[0], flag.ContinueOnError)
 	flags.Usage = func() {
@@ -79,6 +81,7 @@ func (c *CLI) Run(args []string) int {
 	}
 	flags.StringVar(&language, "language", "", "")
 	flags.StringVar(&filename, "filename", "", "")
+	flags.StringVar(&extension, "extension", "", "")
 	flags.BoolVar(&debug, "debug", false, "")
 	flags.BoolVar(&debug, "d", false, "")
 	flags.BoolVar(&version, "version", false, "")
@@ -109,8 +112,9 @@ func (c *CLI) Run(args []string) int {
 	Debugf("keyword: %s", keywords)
 	Debugf("language: %s", language)
 	Debugf("filename: %s", filename)
+	Debugf("extension: %s", extension)
 
-	searcher, err := NewClient(keywords, language, filename)
+	searcher, err := NewClient(keywords, language, filename, extension)
 	if err != nil {
 		return ExitCodeError
 	}
@@ -140,6 +144,9 @@ func (s *Searcher) searchRequest(keyword string, ch chan int) {
 	}
 	if s.filename != "" {
 		query = fmt.Sprintf("%s filename:%s", query, s.filename)
+	}
+	if s.extension != "" {
+		query = fmt.Sprintf("%s extension:%s", query, s.extension)
 	}
 	Debugf("query: %s", query)
 
@@ -232,7 +239,7 @@ func getAccessToken() (string, error) {
 }
 
 // NewClient creates SearchClient
-func NewClient(keywords []string, language string, filename string) (*Searcher, error) {
+func NewClient(keywords []string, language string, filename string, extension string) (*Searcher, error) {
 	token, err := getAccessToken()
 	if err != nil {
 		return nil, err
@@ -258,6 +265,7 @@ func NewClient(keywords []string, language string, filename string) (*Searcher, 
 		keywordsWithTotal: keywordsWithTotal,
 		language:          language,
 		filename:          filename,
+		extension:         extension,
 	}, nil
 }
 
@@ -291,6 +299,8 @@ Options:
   --language     Add language to search term.
 
   --filename     Add filename to search term.
+
+  --extension    Add extension to search term.
 
   -d, --debug    Enable debug mode.
                  Print debug log.

--- a/cli.go
+++ b/cli.go
@@ -62,6 +62,7 @@ type Searcher struct {
 	repository        *api.Repository
 	keywordsWithTotal map[string]int
 	language          string
+	filename          string
 }
 
 // Run invokes the CLI with the given arguments
@@ -69,6 +70,7 @@ func (c *CLI) Run(args []string) int {
 	var (
 		debug    bool
 		language string
+		filename string
 		version  bool
 	)
 	flags := flag.NewFlagSet(args[0], flag.ContinueOnError)
@@ -76,6 +78,7 @@ func (c *CLI) Run(args []string) int {
 		fmt.Fprint(c.errStream, helpText)
 	}
 	flags.StringVar(&language, "language", "", "")
+	flags.StringVar(&filename, "filename", "", "")
 	flags.BoolVar(&debug, "debug", false, "")
 	flags.BoolVar(&debug, "d", false, "")
 	flags.BoolVar(&version, "version", false, "")
@@ -105,8 +108,9 @@ func (c *CLI) Run(args []string) int {
 	keywords := parsedArgs
 	Debugf("keyword: %s", keywords)
 	Debugf("language: %s", language)
+	Debugf("filename: %s", filename)
 
-	searcher, err := NewClient(keywords, language)
+	searcher, err := NewClient(keywords, language, filename)
 	if err != nil {
 		return ExitCodeError
 	}
@@ -133,6 +137,9 @@ func (s *Searcher) searchRequest(keyword string, ch chan int) {
 	query := fmt.Sprintf("%s", keyword)
 	if s.language != "" {
 		query = fmt.Sprintf("%s language:%s", query, s.language)
+	}
+	if s.filename != "" {
+		query = fmt.Sprintf("%s filename:%s", query, s.filename)
 	}
 	Debugf("query: %s", query)
 
@@ -225,7 +232,7 @@ func getAccessToken() (string, error) {
 }
 
 // NewClient creates SearchClient
-func NewClient(keywords []string, language string) (*Searcher, error) {
+func NewClient(keywords []string, language string, filename string) (*Searcher, error) {
 	token, err := getAccessToken()
 	if err != nil {
 		return nil, err
@@ -250,6 +257,7 @@ func NewClient(keywords []string, language string) (*Searcher, error) {
 		repository:        repo,
 		keywordsWithTotal: keywordsWithTotal,
 		language:          language,
+		filename:          filename,
 	}, nil
 }
 
@@ -281,6 +289,8 @@ You must specify keyword what you want to know keyword.
 Options:
 
   --language     Add language to search term.
+
+  --filename     Add filename to search term.
 
   -d, --debug    Enable debug mode.
                  Print debug log.


### PR DESCRIPTION
Fix #5 

# Example

```
% ghkw -d --filename=Gemfile --extension=lock yoshida nakamura
2018/02/08 20:26:13 [DEBUG] Run as DEBUG mode
2018/02/08 20:26:13 [DEBUG] keyword: [yoshida nakamura]
2018/02/08 20:26:13 [DEBUG] language:
2018/02/08 20:26:13 [DEBUG] filename: Gemfile
2018/02/08 20:26:13 [DEBUG] extension: lock
2018/02/08 20:26:14 [DEBUG] query: yoshida filename:Gemfile extension:lock
2018/02/08 20:26:15 [DEBUG] Keyword: yoshida (13)
2018/02/08 20:26:15 [DEBUG] query: nakamura filename:Gemfile extension:lock
2018/02/08 20:26:15 [DEBUG] Keyword: nakamura (1)
| RANK | KEYWORD  | TOTAL |
|------|----------|-------|
|    1 | yoshida  |    13 |
|    2 | nakamura |     1 |
```

The result without filename and extension option.

```
% ghkw -d yoshida nakamura
2018/02/08 20:34:03 [DEBUG] Run as DEBUG mode
2018/02/08 20:34:03 [DEBUG] keyword: [yoshida nakamura]
2018/02/08 20:34:03 [DEBUG] language:
2018/02/08 20:34:03 [DEBUG] filename:
2018/02/08 20:34:03 [DEBUG] extension:
2018/02/08 20:34:04 [DEBUG] query: yoshida
2018/02/08 20:34:05 [DEBUG] Keyword: yoshida (253152)
2018/02/08 20:34:05 [DEBUG] query: nakamura
2018/02/08 20:34:05 [DEBUG] Keyword: nakamura (570095)
| RANK | KEYWORD  |  TOTAL  |
|------|----------|---------|
|    1 | nakamura | 570,095 |
|    2 | yoshida  | 253,152 |
```