### PR TITLE
Refactor search term and modify messages

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -109,12 +109,12 @@ func (c *CLI) Run(args []string) int {
 
 	parsedArgs := flags.Args()
 	if len(parsedArgs) == 0 {
-		PrintErrorf("Invalid argument: you must set keyword.")
+		PrintErrorf("Invalid argument: You must set keyword.")
 		return ExitCodeBadArgs
 	}
 
 	keywords := parsedArgs
-	Debugf("keyword: %s", keywords)
+	Debugf("keywords: %s", keywords)
 	searchTerm := NewSearchTerm(language, filename, extension)
 
 	searcher, err := NewClient(keywords, *searchTerm)
@@ -176,7 +176,7 @@ func (s *Searcher) searchRequest(keyword string, ch chan int) {
 		PrintErrorf("%s\n%s", response.Status, response.Body)
 	}
 
-	Debugf("Keyword: %s (%d)", keyword, *result.Total)
+	Debugf("keyword: %s (%d)", keyword, *result.Total)
 	ch <- *result.Total
 }
 


### PR DESCRIPTION
Refactor search term into a single parameter object.

And, modify messages.

## Before:

```
% ghr -d yoshida nakamura
2018/02/08 21:13:46 [DEBUG] Run as DEBUG mode
2018/02/08 21:13:46 [DEBUG] keyword: [yoshida nakamura]
2018/02/08 21:13:46 [DEBUG] language:
2018/02/08 21:13:46 [DEBUG] filename:
2018/02/08 21:13:46 [DEBUG] extension:
2018/02/08 21:13:47 [DEBUG] query: yoshida
2018/02/08 21:13:47 [DEBUG] Keyword: yoshida (253156)
2018/02/08 21:13:47 [DEBUG] query: nakamura
2018/02/08 21:13:49 [DEBUG] Keyword: nakamura (570116)
| RANK | KEYWORD  |  TOTAL  |
|------|----------|---------|
|    1 | nakamura | 570,116 |
|    2 | yoshida  | 253,156 |
```

## After

```
% ghr -d yoshida nakamura
2018/02/08 21:20:04 [DEBUG] Run as DEBUG mode
2018/02/08 21:20:04 [DEBUG] keywords: [yoshida nakamura]
2018/02/08 21:20:04 [DEBUG] language:
2018/02/08 21:20:04 [DEBUG] filename:
2018/02/08 21:20:04 [DEBUG] extension:
2018/02/08 21:20:05 [DEBUG] query: yoshida
2018/02/08 21:20:06 [DEBUG] keyword: yoshida (253157)
2018/02/08 21:20:06 [DEBUG] query: nakamura
2018/02/08 21:20:07 [DEBUG] keyword: nakamura (570126)
| RANK | KEYWORD  |  TOTAL  |
|------|----------|---------|
|    1 | nakamura | 570,126 |
|    2 | yoshida  | 253,157 |
```