### PR TITLE
Fix wrong rank

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -221,8 +221,18 @@ func sortMapByValue(m map[string]int) PairList {
 
 func (s *Searcher) output(outStream io.Writer) {
 	data := [][]string{}
+	var prevRank, prevTotal int = -1, -1
+	var _rank int
 	for i, pl := range sortMapByValue(s.keywordsWithTotal) {
-		rank := fmt.Sprintf("%d", i+1)
+		if prevTotal == pl.value {
+			_rank = prevRank
+		} else {
+			_rank = i + 1
+			prevRank = _rank
+		}
+		prevTotal = pl.value
+
+		rank := fmt.Sprintf("%d", _rank)
 		keyword := pl.key
 		total := fmt.Sprintf("%s", humanize.Comma(int64(pl.value)))
 		data = append(data,


### PR DESCRIPTION
- Fix problem a keyword isn't displayed when including same total value in keywords
- Fix the wrong rank when total value of keywords are same (Also, fix #9)

## Before

```
% ghkw  -d githubgithubgithub excluded_condition __no_hit__
2018/02/10 13:01:47 [DEBUG] Run as DEBUG mode
2018/02/10 13:01:47 [DEBUG] keywords: [githubgithubgithub excluded_condition __no_hit__]
2018/02/10 13:01:47 [DEBUG] language:
2018/02/10 13:01:47 [DEBUG] filename:
2018/02/10 13:01:47 [DEBUG] extension:
2018/02/10 13:01:47 [DEBUG] query: githubgithubgithub
2018/02/10 13:01:48 [DEBUG] keyword: githubgithubgithub (4)
2018/02/10 13:01:48 [DEBUG] query: excluded_condition
2018/02/10 13:01:49 [DEBUG] keyword: excluded_condition (4)
2018/02/10 13:01:49 [DEBUG] query: __no_hit__
2018/02/10 13:01:49 [DEBUG] keyword: __no_hit__ (0)
| RANK |      KEYWORD       | TOTAL |
|------|--------------------|-------|
|    1 | excluded_condition |     4 |
|    2 | excluded_condition |     4 |
|    3 | __no_hit__         |     0 |
```

- `excluded_condition` is displayed twice
- `githubgithubgithub` isn't displayed
- "RANK" should be same if "TOTAL" is same

## After

```
% ghkw -d githubgithubgithub excluded_condition __no_hit__
2018/02/10 12:49:37 [DEBUG] Run as DEBUG mode
2018/02/10 12:49:37 [DEBUG] keywords: [githubgithubgithub excluded_condition __no_hit__]
2018/02/10 12:49:37 [DEBUG] language:
2018/02/10 12:49:37 [DEBUG] filename:
2018/02/10 12:49:37 [DEBUG] extension:
2018/02/10 12:49:37 [DEBUG] query: githubgithubgithub
2018/02/10 12:49:38 [DEBUG] keyword: githubgithubgithub (4)
2018/02/10 12:49:38 [DEBUG] query: excluded_condition
2018/02/10 12:49:38 [DEBUG] keyword: excluded_condition (4)
2018/02/10 12:49:38 [DEBUG] query: __no_hit__
2018/02/10 12:49:38 [DEBUG] keyword: __no_hit__ (0)
| RANK |      KEYWORD       | TOTAL |
|------|--------------------|-------|
|    1 | githubgithubgithub |     4 |
|    1 | excluded_condition |     4 |
|    3 | __no_hit__         |     0 |
```