### PR TITLE
Support all of code search qualifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ $ ghkw exclusion_condition exclude_condition excluded_condition
 
 --user         Add user to search term.
 
+--repo         Add repo to search term.
+
 -d, --debug    Enable debug mode.
                Print debug log.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ $ ghkw exclusion_condition exclude_condition excluded_condition
 
 --extension    Add extension to search term.
 
+--user         Add user to search term.
+
 -d, --debug    Enable debug mode.
                Print debug log.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ $ ghkw exclusion_condition exclude_condition excluded_condition
 ```
 --language     Add language to search term.
 
+--path         Add path to search term.
+
 --filename     Add filename to search term.
 
 --extension    Add extension to search term.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ $ ghkw exclusion_condition exclude_condition excluded_condition
 ### Options
 
 ```
+--in           Add in to search term.
+
 --language     Add language to search term.
 
 --fork         Add fork to search term.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ $ ghkw exclusion_condition exclude_condition excluded_condition
 ```
 --language     Add language to search term.
 
+--fork         Add fork to search term.
+
 --size         Add size to search term.
 
 --path         Add path to search term.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ $ ghkw exclusion_condition exclude_condition excluded_condition
 |    3 | excluded_condition  |     2 |
 ```
 
+A search condition is in the file contents, language is javascript and file size is over 1,000bytes.
+
+```
+$ ghkw --in=file --language=javascript --size=">1000" exclude_condition exclusion_condition
+```
+
 ### Options
 
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ $ ghkw exclusion_condition exclude_condition excluded_condition
 ```
 --language     Add language to search term.
 
+--size         Add size to search term.
+
 --path         Add path to search term.
 
 --filename     Add filename to search term.

--- a/cli.go
+++ b/cli.go
@@ -117,7 +117,12 @@ func (c *CLI) Run(args []string) int {
 
 	keywords := parsedArgs
 	Debugf("keywords: %s", keywords)
-	searchTerm := NewSearchTerm(language, filename, extension)
+
+	searchTerm := NewSearchTerm()
+	searchTerm.language = language
+	searchTerm.filename = filename
+	searchTerm.extension = extension
+	searchTerm.debugf()
 
 	searcher, err := NewClient(keywords, *searchTerm)
 	if err != nil {

--- a/cli.go
+++ b/cli.go
@@ -64,13 +64,6 @@ type Searcher struct {
 	searchTerm        *SearchTerm
 }
 
-// SearchTerm is search term in GitHub object
-type SearchTerm struct {
-	language  string
-	filename  string
-	extension string
-}
-
 // PairList is list of Pair
 type PairList []Pair
 
@@ -139,32 +132,6 @@ func (c *CLI) Run(args []string) int {
 	searcher.output(c.outStream)
 
 	return ExitCodeOK
-}
-
-func NewSearchTerm(language string, filename string, extension string) *SearchTerm {
-	Debugf("language: %s", language)
-	Debugf("filename: %s", filename)
-	Debugf("extension: %s", extension)
-
-	return &SearchTerm{
-		language:  language,
-		filename:  filename,
-		extension: extension,
-	}
-}
-
-func (s *SearchTerm) query(keyword string) string {
-	q := keyword
-	if s.language != "" {
-		q = fmt.Sprintf("%s language:%s", q, s.language)
-	}
-	if s.filename != "" {
-		q = fmt.Sprintf("%s filename:%s", q, s.filename)
-	}
-	if s.extension != "" {
-		q = fmt.Sprintf("%s extension:%s", q, s.extension)
-	}
-	return q
 }
 
 func (s *Searcher) keywords() []string {

--- a/cli.go
+++ b/cli.go
@@ -78,6 +78,7 @@ func (c *CLI) Run(args []string) int {
 	var (
 		debug     bool
 		language  string
+		path      string
 		filename  string
 		extension string
 		user      string
@@ -89,6 +90,7 @@ func (c *CLI) Run(args []string) int {
 		fmt.Fprint(c.errStream, helpText)
 	}
 	flags.StringVar(&language, "language", "", "")
+	flags.StringVar(&path, "path", "", "")
 	flags.StringVar(&filename, "filename", "", "")
 	flags.StringVar(&extension, "extension", "", "")
 	flags.StringVar(&user, "user", "", "")
@@ -124,6 +126,7 @@ func (c *CLI) Run(args []string) int {
 
 	searchTerm := NewSearchTerm()
 	searchTerm.language = language
+	searchTerm.path = path
 	searchTerm.filename = filename
 	searchTerm.extension = extension
 	searchTerm.user = user
@@ -318,6 +321,8 @@ You must specify keyword what you want to know keyword.
 Options:
 
   --language     Add language to search term.
+
+  --path         Add path to search term.
 
   --filename     Add filename to search term.
 

--- a/cli.go
+++ b/cli.go
@@ -80,6 +80,7 @@ func (c *CLI) Run(args []string) int {
 		language  string
 		filename  string
 		extension string
+		user      string
 		version   bool
 	)
 	flags := flag.NewFlagSet(args[0], flag.ContinueOnError)
@@ -89,6 +90,7 @@ func (c *CLI) Run(args []string) int {
 	flags.StringVar(&language, "language", "", "")
 	flags.StringVar(&filename, "filename", "", "")
 	flags.StringVar(&extension, "extension", "", "")
+	flags.StringVar(&user, "user", "", "")
 	flags.BoolVar(&debug, "debug", false, "")
 	flags.BoolVar(&debug, "d", false, "")
 	flags.BoolVar(&version, "version", false, "")
@@ -122,6 +124,7 @@ func (c *CLI) Run(args []string) int {
 	searchTerm.language = language
 	searchTerm.filename = filename
 	searchTerm.extension = extension
+	searchTerm.user = user
 	searchTerm.debugf()
 
 	searcher, err := NewClient(keywords, *searchTerm)
@@ -316,6 +319,8 @@ Options:
   --filename     Add filename to search term.
 
   --extension    Add extension to search term.
+
+  --user         Add user to search term.
 
   -d, --debug    Enable debug mode.
                  Print debug log.

--- a/cli.go
+++ b/cli.go
@@ -78,6 +78,7 @@ func (c *CLI) Run(args []string) int {
 	var (
 		debug     bool
 		language  string
+		fork      string
 		size      string
 		path      string
 		filename  string
@@ -91,6 +92,7 @@ func (c *CLI) Run(args []string) int {
 		fmt.Fprint(c.errStream, helpText)
 	}
 	flags.StringVar(&language, "language", "", "")
+	flags.StringVar(&fork, "fork", "", "")
 	flags.StringVar(&size, "size", "", "")
 	flags.StringVar(&path, "path", "", "")
 	flags.StringVar(&filename, "filename", "", "")
@@ -128,6 +130,7 @@ func (c *CLI) Run(args []string) int {
 
 	searchTerm := NewSearchTerm()
 	searchTerm.language = language
+	searchTerm.fork = fork
 	searchTerm.size = size
 	searchTerm.path = path
 	searchTerm.filename = filename
@@ -324,6 +327,8 @@ You must specify keyword what you want to know keyword.
 Options:
 
   --language     Add language to search term.
+
+  --fork         Add fork to search term.
 
   --size         Add size to search term.
 

--- a/cli.go
+++ b/cli.go
@@ -329,28 +329,38 @@ You must specify keyword what you want to know keyword.
 
 Options:
 
-  --in           Add in to search term.
-
-  --language     Add language to search term.
-
-  --fork         Add fork to search term.
-
-  --size         Add size to search term.
-
-  --path         Add path to search term.
-
-  --filename     Add filename to search term.
-
-  --extension    Add extension to search term.
-
-  --user         Add user to search term.
-
-  --repo         Add repo to search term.
-
   -d, --debug    Enable debug mode.
                  Print debug log.
 
   -h, --help     Show this help message and exit.
 
   -v, --version  Print current version.
+
+  Search Qualifiers:
+
+    --in           Add in to search term.
+  
+    --language     Add language to search term.
+  
+    --fork         Add fork to search term.
+  
+    --size         Add size to search term.
+  
+    --path         Add path to search term.
+  
+    --filename     Add filename to search term.
+  
+    --extension    Add extension to search term.
+  
+    --user         Add user to search term.
+  
+    --repo         Add repo to search term.
+
+    See Also:
+      https://developer.github.com/v3/search/#parameters-2
+
+Examples:
+    The following is how to do ghkw search "exclude_condition" and "exclusion_condition" with search option in the file contents, language is javascript and file size is over 1,000bytes.
+
+    ghkw --in=file --language=javascript --size=">1000" exclude_condition exclusion_condition
 `

--- a/cli.go
+++ b/cli.go
@@ -77,6 +77,7 @@ type Pair struct {
 func (c *CLI) Run(args []string) int {
 	var (
 		debug     bool
+		in        string
 		language  string
 		fork      string
 		size      string
@@ -91,6 +92,7 @@ func (c *CLI) Run(args []string) int {
 	flags.Usage = func() {
 		fmt.Fprint(c.errStream, helpText)
 	}
+	flags.StringVar(&in, "in", "", "")
 	flags.StringVar(&language, "language", "", "")
 	flags.StringVar(&fork, "fork", "", "")
 	flags.StringVar(&size, "size", "", "")
@@ -129,6 +131,7 @@ func (c *CLI) Run(args []string) int {
 	Debugf("keywords: %s", keywords)
 
 	searchTerm := NewSearchTerm()
+	searchTerm.in = in
 	searchTerm.language = language
 	searchTerm.fork = fork
 	searchTerm.size = size
@@ -325,6 +328,8 @@ ghkw is a tool to know how many keyword is used in GitHub code.
 You must specify keyword what you want to know keyword.
 
 Options:
+
+  --in           Add in to search term.
 
   --language     Add language to search term.
 

--- a/cli.go
+++ b/cli.go
@@ -78,6 +78,7 @@ func (c *CLI) Run(args []string) int {
 	var (
 		debug     bool
 		language  string
+		size      string
 		path      string
 		filename  string
 		extension string
@@ -90,6 +91,7 @@ func (c *CLI) Run(args []string) int {
 		fmt.Fprint(c.errStream, helpText)
 	}
 	flags.StringVar(&language, "language", "", "")
+	flags.StringVar(&size, "size", "", "")
 	flags.StringVar(&path, "path", "", "")
 	flags.StringVar(&filename, "filename", "", "")
 	flags.StringVar(&extension, "extension", "", "")
@@ -126,6 +128,7 @@ func (c *CLI) Run(args []string) int {
 
 	searchTerm := NewSearchTerm()
 	searchTerm.language = language
+	searchTerm.size = size
 	searchTerm.path = path
 	searchTerm.filename = filename
 	searchTerm.extension = extension
@@ -321,6 +324,8 @@ You must specify keyword what you want to know keyword.
 Options:
 
   --language     Add language to search term.
+
+  --size         Add size to search term.
 
   --path         Add path to search term.
 

--- a/cli.go
+++ b/cli.go
@@ -81,6 +81,7 @@ func (c *CLI) Run(args []string) int {
 		filename  string
 		extension string
 		user      string
+		repo      string
 		version   bool
 	)
 	flags := flag.NewFlagSet(args[0], flag.ContinueOnError)
@@ -91,6 +92,7 @@ func (c *CLI) Run(args []string) int {
 	flags.StringVar(&filename, "filename", "", "")
 	flags.StringVar(&extension, "extension", "", "")
 	flags.StringVar(&user, "user", "", "")
+	flags.StringVar(&repo, "repo", "", "")
 	flags.BoolVar(&debug, "debug", false, "")
 	flags.BoolVar(&debug, "d", false, "")
 	flags.BoolVar(&version, "version", false, "")
@@ -125,6 +127,7 @@ func (c *CLI) Run(args []string) int {
 	searchTerm.filename = filename
 	searchTerm.extension = extension
 	searchTerm.user = user
+	searchTerm.repo = repo
 	searchTerm.debugf()
 
 	searcher, err := NewClient(keywords, *searchTerm)
@@ -321,6 +324,8 @@ Options:
   --extension    Add extension to search term.
 
   --user         Add user to search term.
+
+  --repo         Add repo to search term.
 
   -d, --debug    Enable debug mode.
                  Print debug log.

--- a/search_term.go
+++ b/search_term.go
@@ -11,6 +11,7 @@ type SearchTerm struct {
 	language  string
 	filename  string
 	extension string
+	user      string
 }
 
 // NewSearchTerm creates SearchTerm

--- a/search_term.go
+++ b/search_term.go
@@ -9,6 +9,7 @@ import (
 // See: https://developer.github.com/v3/search/#parameters-2
 type SearchTerm struct {
 	language  string
+	path      string
 	filename  string
 	extension string
 	user      string

--- a/search_term.go
+++ b/search_term.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+)
+
+// SearchTerm is search term in GitHub object
+type SearchTerm struct {
+	language  string
+	filename  string
+	extension string
+}
+
+// NewSearchTerm creates SearchTerm
+func NewSearchTerm(language string, filename string, extension string) *SearchTerm {
+	Debugf("language: %s", language)
+	Debugf("filename: %s", filename)
+	Debugf("extension: %s", extension)
+
+	return &SearchTerm{
+		language:  language,
+		filename:  filename,
+		extension: extension,
+	}
+}
+
+func (s *SearchTerm) query(keyword string) string {
+	q := keyword
+	if s.language != "" {
+		q = fmt.Sprintf("%s language:%s", q, s.language)
+	}
+	if s.filename != "" {
+		q = fmt.Sprintf("%s filename:%s", q, s.filename)
+	}
+	if s.extension != "" {
+		q = fmt.Sprintf("%s extension:%s", q, s.extension)
+	}
+	return q
+}

--- a/search_term.go
+++ b/search_term.go
@@ -8,6 +8,7 @@ import (
 // SearchTerm is search term in GitHub object
 // See: https://developer.github.com/v3/search/#parameters-2
 type SearchTerm struct {
+	in        string
 	language  string
 	fork      string
 	size      string

--- a/search_term.go
+++ b/search_term.go
@@ -9,6 +9,7 @@ import (
 // See: https://developer.github.com/v3/search/#parameters-2
 type SearchTerm struct {
 	language  string
+	size      string
 	path      string
 	filename  string
 	extension string

--- a/search_term.go
+++ b/search_term.go
@@ -9,6 +9,7 @@ import (
 // See: https://developer.github.com/v3/search/#parameters-2
 type SearchTerm struct {
 	language  string
+	fork      string
 	size      string
 	path      string
 	filename  string

--- a/search_term.go
+++ b/search_term.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"fmt"
+	"reflect"
 )
 
 // SearchTerm is search term in GitHub object
+// See: https://developer.github.com/v3/search/#parameters-2
 type SearchTerm struct {
 	language  string
 	filename  string
@@ -12,28 +14,35 @@ type SearchTerm struct {
 }
 
 // NewSearchTerm creates SearchTerm
-func NewSearchTerm(language string, filename string, extension string) *SearchTerm {
-	Debugf("language: %s", language)
-	Debugf("filename: %s", filename)
-	Debugf("extension: %s", extension)
+func NewSearchTerm() *SearchTerm {
+	return &SearchTerm{}
+}
 
-	return &SearchTerm{
-		language:  language,
-		filename:  filename,
-		extension: extension,
+func (s *SearchTerm) debugf() {
+	v := reflect.Indirect(reflect.ValueOf(s))
+	t := v.Type()
+
+	var name, value string
+	for i := 0; i < t.NumField(); i++ {
+		name = t.Field(i).Name
+		value = v.Field(i).String()
+		Debugf("%s: %s", name, value)
 	}
 }
 
 func (s *SearchTerm) query(keyword string) string {
 	q := keyword
-	if s.language != "" {
-		q = fmt.Sprintf("%s language:%s", q, s.language)
-	}
-	if s.filename != "" {
-		q = fmt.Sprintf("%s filename:%s", q, s.filename)
-	}
-	if s.extension != "" {
-		q = fmt.Sprintf("%s extension:%s", q, s.extension)
+	v := reflect.Indirect(reflect.ValueOf(s))
+	t := v.Type()
+
+	var name, value string
+	for i := 0; i < t.NumField(); i++ {
+		name = t.Field(i).Name
+		value = v.Field(i).String()
+
+		if value != "" {
+			q = fmt.Sprintf("%s %s:%s", q, name, value)
+		}
 	}
 	return q
 }

--- a/search_term.go
+++ b/search_term.go
@@ -12,6 +12,7 @@ type SearchTerm struct {
 	filename  string
 	extension string
 	user      string
+	repo      string
 }
 
 // NewSearchTerm creates SearchTerm


### PR DESCRIPTION
Support the following code search qualifiers.

- `user`
- `repo`
- `path`
- `size`
- `fork`
- `in`

Example:

```
$ ghkw --in=file --language=javascript --size=">1000" exclude_condition exclusion_condition
```

For more detail about these qualifiers, see https://developer.github.com/v3/search/#search-code

Also, fix #6 