### PR TITLE
Fix 422 error when keyword has :(colon)

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -36,6 +37,9 @@ const (
 	ExitCodeParseFlagsError
 	ExitCodeBadArgs
 )
+
+// Ignore char in keyword
+const IGNORE_KEYWORD_CHAR = ":"
 
 // Debugf prints debug output when EnvDebug is given
 func Debugf(format string, args ...interface{}) {
@@ -273,6 +277,10 @@ func getAccessToken() (string, error) {
 	return token, nil
 }
 
+func sanitizeKeyword(keyword string) string {
+	return strings.Replace(keyword, IGNORE_KEYWORD_CHAR, "", -1)
+}
+
 // NewClient creates SearchClient
 func NewClient(keywords []string, searchTerm SearchTerm) (*Searcher, error) {
 	token, err := getAccessToken()
@@ -290,7 +298,7 @@ func NewClient(keywords []string, searchTerm SearchTerm) (*Searcher, error) {
 
 	keywordsWithTotal := map[string]int{}
 	for i := range keywords {
-		keyword := keywords[i]
+		keyword := sanitizeKeyword(keywords[i])
 		keywordsWithTotal[keyword] = 0
 	}
 


### PR DESCRIPTION
Fix #10 

Ignore `:` in keyword.

Example:

```
% ghkw  -d language:javascript
2018/02/10 19:29:27 [DEBUG] Run as DEBUG mode
2018/02/10 19:29:27 [DEBUG] keywords: [language:javascript]
2018/02/10 19:29:27 [DEBUG] in:
2018/02/10 19:29:27 [DEBUG] language:
2018/02/10 19:29:27 [DEBUG] fork:
2018/02/10 19:29:27 [DEBUG] size:
2018/02/10 19:29:27 [DEBUG] path:
2018/02/10 19:29:27 [DEBUG] filename:
2018/02/10 19:29:27 [DEBUG] extension:
2018/02/10 19:29:27 [DEBUG] user:
2018/02/10 19:29:27 [DEBUG] repo:
2018/02/10 19:29:27 [DEBUG] query: languagejavascript
2018/02/10 19:29:29 [DEBUG] keyword: languagejavascript (994)
| RANK |      KEYWORD       | TOTAL |
|------|--------------------|-------|
|    1 | languagejavascript |   994 |
```